### PR TITLE
Specify encoding to ensure Python reads file as UTF-8

### DIFF
--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -43,7 +43,7 @@ args = parser.parse_args()
 asr, tokenizer = backend_factory(args)
 
 # Load demo HTML for the root endpoint
-with open("src/live_transcription.html", "r") as f:
+with open("src/live_transcription.html", "r", encoding="utf-8") as f:
     html = f.read()
 
 


### PR DESCRIPTION
**Issue:**
Executing `python whisper_fastapi_online_server.py --host 0.0.0.0 --port 8000` resulted in error on my setup for me:

```
whisper_streaming_web\whisper_fastapi_online_server.py, line 47, in <module>
    html = f.read()
           ^^^^^^^^
  File "C:\Python312\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1818: character maps to <undefined>
```

**Why this occurs:**
 Python defaults to the `cp1252` encoding, which doesnt match the encoding of the file containing special characters or saved with UTF-8 encoding

**Fix:**
Specify encoding to ensure Python reads file as UTF-8