### PR TITLE
Finish transcribe after stoping 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 *.wav
 run_*.sh
+pixi*
+.pixi

--- a/timed_objects.py
+++ b/timed_objects.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List, Callable, Tuple
+from typing import Optional, Union, List, Callable, Tuple
 from itertools import groupby
 
 import logging
@@ -150,7 +150,7 @@ class TimedList(list):
         for segment in self:
             segment.shift(shift)
 
-    def extend(self, other: List[TimedText] | 'TimedList'):
+    def extend(self, other: Union[List[TimedText], 'TimedList']):
         """
         Extend the sequence with another sequence of TimedText instances.
         """
@@ -202,7 +202,7 @@ class TimedList(list):
         else:
             return super().__getitem__(index)
 
-    def __add__(self, other: List[TimedText] | 'TimedList') -> 'TimedList':
+    def __add__(self, other: Union[List[TimedText], 'TimedList']) -> 'TimedList':
         """
         Add two TimedLists together.
         """
@@ -271,7 +271,7 @@ class TimedList(list):
 
 
 
-    def split_to_sentences(self, sentence_splitter: Optional[Callable[[str], List[str]] | Callable[[List[str]], List[str]]] = None) -> List['TimedList']:
+    def split_to_sentences(self, sentence_splitter: Optional[Union[Callable[[str], List[str]], Callable[[List[str]], List[str]]]] = None) -> List['TimedList']:
             """
             Converts a list of tokens to a list of Sentence objects using the provided
             sentence tokenizer.
@@ -299,7 +299,7 @@ class TimedList(list):
 
 
 
-def run_sentence_splitter(input_sentences: 'TimedList',sentence_splitter: Callable[[str], List[str]] | Callable[[List[str]], List[str]]) -> List['TimedList']:
+def run_sentence_splitter(input_sentences: 'TimedList',sentence_splitter: Union[Callable[[str], List[str]], Callable[[List[str]], List[str]]]) -> List['TimedList']:
     """
     Run the sentence splitter on the transcript.
     """

--- a/timed_objects.py
+++ b/timed_objects.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List, Callable
+
+import logging
+logger = logging.getLogger(__name__)
 
 @dataclass
 class TimedText:
@@ -8,6 +11,10 @@ class TimedText:
     text: Optional[str] = ''
     speaker: Optional[int] = -1
     probability: Optional[float] = None
+
+    def shift(self, offset: float) -> None:
+        self.start += offset
+        self.end += offset
 
 @dataclass
 class ASRToken(TimedText):
@@ -26,3 +33,193 @@ class Transcript(TimedText):
 @dataclass
 class SpeakerSegment(TimedText):
     pass
+
+
+class TimedList(list):
+    """
+    Represents a collection of TimedText instances.
+    """
+    def __init__(self, words: List[TimedText] = None,sep=None):
+        words = words if words is not None else []
+        super().__init__(words)
+        
+        self.sep= sep
+
+
+
+
+    def infer_sep(self) -> None:
+        if len(self) == 0:
+            return " "
+
+        n_tailing_spaces = 0
+        for word in self:
+            if word.text.endswith(' ') or word.text.startswith(' '):
+                n_tailing_spaces += 1
+
+
+        if n_tailing_spaces / len(self) > 0.8:
+            sep=""
+        else:
+            sep= " "
+        
+        logger.debug(f"{n_tailing_spaces} words of {len(self)} have tailing spaces I will use '{sep}' to join them")
+        self.sep = sep
+
+    def concatenate(self, sep: Optional[str] = None, offset: float = 0) -> TimedText:
+        """
+        Concatenates all segments in the sequence into a single segment.
+
+        Returns:
+            TimedText: A single segment containing all text from the sequence.
+
+        Example:
+            >>> sequence = TimedList([TimedText(0.0, 1.0, "Hello"), TimedText(1.0, 2.0, "World")])
+            >>> sequence.sep==" "
+            True
+            >>> sequence.concatenate()
+            TimedText(start=0.0, end=2.0, text='Hello World')
+        """
+
+        if len(self) == 0:
+            return TimedText(None, None)
+        
+
+        text = self.get_text(sep)
+        probability = sum(word.probability for word in self if word.probability) / len(self)
+
+        start = offset + self[0].start
+        end = offset + self[-1].end
+
+        return TimedText(start, end, text, probability=probability)
+
+    
+    def get_text(self,sep: Optional[str] = None) -> str:
+        """
+        Returns the text of all segments in the sequence.
+
+        Returns:
+            str: The text of all segments in the sequence.
+
+        Example:
+            >>> sequence = TimedList([TimedText(0.0, 1.0, "Hello"), TimedText(1.0, 2.0, "World")])
+            >>> sequence.get_text()
+            'Hello World'
+        """
+
+        if len(self) == 0:
+            return ""
+
+        if sep is None:
+            if self.sep is None:
+                self.infer_sep()
+            sep = self.sep
+        elif self.sep is None:
+            self.sep = sep
+        
+        return sep.join(word.text for word in self)
+    
+    def shift(self, shift: float) -> None:
+        """
+        Shifts all segments in the sequence by a given amount of time.
+
+        Args:
+            shift (float): The amount of time to shift the segments.
+
+        Returns:
+            TimedList: A new sequence with all segments shifted by the given amount of time.
+
+        Example:
+            >>> sequence = TimedList([TimedText(0.0, 1.0, "Hello"), TimedText(1.0, 2.0, "World")])
+            >>> sequence.shift(1.0)
+            >>> sequence
+            [TimedText(start=1.0, end=2.0, text='Hello'), TimedText(start=2.0, end=3.0, text='World')]
+        """
+        for segment in self:
+            segment.shift(shift)
+
+    def extend(self, other: List[TimedText] | 'TimedList'):
+        """
+        Extend the sequence with another sequence of TimedText instances.
+        """
+        assert isinstance(other, TimedList), "Expect a TimedList to extend"
+        
+        if len(other) == 0:
+            return
+        elif len(self) == 0:
+            super().extend(other)
+            self.sep = other.sep
+            return
+        else:
+            if self.sep != other.sep:
+                logger.warning(f"Two TimedLists with different separators are being extended: {self.sep} != {other.sep} use ' ' in future")
+                self.sep = ' '
+            super().extend(other)
+        
+        
+
+    
+    def __repr__(self):
+        return super().__repr__()
+    
+    def __str__(self):
+
+        if len(self) == 0:
+            return "[]"
+        if len(self) <= 5:
+            return f"[{self.get_text()} ({self[0].start:.3f} - {self[-1].end:.3f})]"
+
+        return "[{first}…{last} ({n} words {start:.3f} - {end:.3f})]".format(
+            n= len(self),
+            start= self[0].start,
+            end= self[-1].end,
+            first= self.sep.join((self[0],self[1])),
+            last= self.sep.join((self[-2],self[-1]))
+        )
+
+
+    def split_to_sentences(self, sentence_splitter: Optional[Callable[[str], List[str]] | Callable[[List[str]], List[str]]] = None) -> 'TimedList':
+            """
+            Converts a list of tokens to a list of Sentence objects using the provided
+            sentence tokenizer.
+            """
+            if len(self) == 0:
+                return TimedList([])
+            
+
+            if sentence_splitter is None:
+                logger.warning("No sentence splitter provided, concatenating tokens")
+                return self.concatenate()
+
+            full_text = self.get_text()
+
+            try:
+                sentence_texts = self.tokenize([full_text])
+            except Exception as e:
+                # Some tokenizers (e.g., MosesSentenceSplitter) expect a list input.
+                try:
+                    sentence_texts = self.tokenize(full_text)
+                except Exception as e2:
+                    raise ValueError("Tokenization failed") from e2
+
+            # Match output of sentence splitter to the input tokens
+            sentences: TimedList = TimedList([])
+            token_index = 0
+
+            for sent_text in sentence_texts:
+                sent_text = sent_text.strip()
+                if not sent_text:
+                    continue
+                sent_tokens = TimedList([])
+
+                accumulated = ""
+                # Accumulate tokens until roughly matching the length of the sentence text.
+                while token_index < len(self) and len(accumulated) < len(sent_text):
+                    token = self[token_index]
+                    accumulated = (accumulated + self.sep + token.text).strip() if accumulated else token.text
+                    sent_tokens.append(token)
+                    token_index += 1
+                if sent_tokens:
+                    sentences.append(sent_tokens.concatenate())
+            return sentences
+

--- a/timed_objects.py
+++ b/timed_objects.py
@@ -158,9 +158,13 @@ class TimedList(list):
             self.sep = other.sep
             return
         else:
-            if self.sep != other.sep:
-                logger.warning(f"Two TimedLists with different separators are being extended: {self.sep} != {other.sep} use ' ' in future")
-                self.sep = ' '
+            if (self.sep != other.sep):
+                if self.sep is None:
+                    self.sep = other.sep
+                elif other.sep is not None:
+                    logger.warning(f"Two TimedLists with different separators are being extended: '{self.sep}' != '{other.sep}' use ' ' in future")
+                    self.sep = ' '
+
             super().extend(other)
         
         

--- a/timed_objects.py
+++ b/timed_objects.py
@@ -252,13 +252,13 @@ class TimedList(list):
             full_text = self.get_text()
 
             try:
-                sentence_texts = self.tokenize([full_text])
-            except Exception as e:
-                # Some tokenizers (e.g., MosesSentenceSplitter) expect a list input.
+                # most tokenizers (e.g., MosesSentenceSplitter) expect a list input.
+                sentence_texts = sentence_splitter([full_text])
+            except Exception as e:   
                 try:
-                    sentence_texts = self.tokenize(full_text)
+                    sentence_texts = sentence_splitter(full_text)
                 except Exception as e2:
-                    raise ValueError("Tokenization failed") from e2
+                    raise ValueError("Tokenization failed") from e
 
             # Match output of sentence splitter to the input tokens
             sentences: TimedList = TimedList([])

--- a/timed_objects.py
+++ b/timed_objects.py
@@ -222,7 +222,7 @@ class TimedList(list):
             # find the first word that ends after the time
             # word at i goes to the right list
             for i, word in enumerate(self):
-                if word.end > time:
+                if word.end >= time:
                     break
             else:
                 return self, TimedList([])

--- a/timed_objects.py
+++ b/timed_objects.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional, List, Callable, Tuple
+from itertools import groupby
 
 import logging
 logger = logging.getLogger(__name__)
@@ -39,13 +40,17 @@ class TimedList(list):
     """
     Represents a collection of TimedText instances.
     """
-    def __init__(self, words: List[TimedText] = None,sep=None):
-        words = words if words is not None else []
+    def __init__(self, words: List[TimedText] = None,sep:Optional[str]=None):
+        if words is None:
+            words = []
+
+        for word in words:
+            if not isinstance(word, TimedText):
+                raise ValueError(f"Expect a TimedText instance, got {type(word)}")
+
         super().__init__(words)
         
         self.sep= sep
-
-
 
 
     def infer_sep(self) -> None:
@@ -174,25 +179,35 @@ class TimedList(list):
         return super().__repr__()
     
     def __str__(self):
+        """
+        Returns a string representation of the TimedList.
+        Example:
+            >>> tokens = TimedList([TimedText(0.0, 1.0, "Hello"), TimedText(1.0, 2.0, "all"), TimedText(2.0, 3.0, "Together!")])
+            >>> print(tokens)
+            [Hello all Together! (0.000 - 3.000)]
+        """
 
         if len(self) == 0:
             return "[]"
-        if len(self) <= 5:
-            return f"[{self.get_text()} ({self[0].start:.3f} - {self[-1].end:.3f})]"
 
-        return "[{first}…{last} ({n} words {start:.3f} - {end:.3f})]".format(
-            n= len(self),
-            start= self[0].start,
-            end= self[-1].end,
-            first= self.sep.join((self[0],self[1])),
-            last= self.sep.join((self[-2],self[-1]))
-        )
+        else:
+            combined_text = self.concatenate()
+            return f"[{combined_text.text} ({combined_text.start:.3f} - {combined_text.end:.3f})]"
+
+
 
     def __getitem__(self, index: int) -> TimedText:
         if isinstance(index, slice):
             return TimedList(super().__getitem__(index), sep=self.sep)
         else:
             return super().__getitem__(index)
+
+    def __add__(self, other: List[TimedText] | 'TimedList') -> 'TimedList':
+        """
+        Add two TimedLists together.
+        """
+        assert isinstance(other, TimedList), "Expect a TimedList to add"
+        return TimedList(super().__add__(other), sep=self.sep)
 
     def split_at(self, time: float, edge_word_goes_left: bool) -> Tuple['TimedList', 'TimedList']:
         """
@@ -236,54 +251,96 @@ class TimedList(list):
         
 
 
+    def split_by_speaker(self) -> List['TimedList']:
+        """
+        Split the sequence by speaker.
+        Returns a list of TimedLists, each containing tokens from a single speaker.
 
+        Example:
+            >>> tokens = TimedList([TimedText(0.0, 1.0, "Hello", speaker=0),TimedText(1.0,2.0,"Everybody.",speaker=0), TimedText(2.0, 3.0, "Bonjour!", speaker=1)])
+            >>> split_by_speaker = tokens.split_by_speaker()
+            >>> len(split_by_speaker)
+            2
+            >>> split_by_speaker[0].get_text()
+            'Hello Everybody.'
+            >>> split_by_speaker[1].get_text()
+            'Bonjour!'
+        """
+        return [TimedList(list(word_iterator), sep=self.sep) for _,word_iterator in groupby(self, key=lambda x: x.speaker)]
         
 
 
-    def split_to_sentences(self, sentence_splitter: Optional[Callable[[str], List[str]] | Callable[[List[str]], List[str]]] = None) -> 'TimedList':
+
+    def split_to_sentences(self, sentence_splitter: Optional[Callable[[str], List[str]] | Callable[[List[str]], List[str]]] = None) -> List['TimedList']:
             """
             Converts a list of tokens to a list of Sentence objects using the provided
             sentence tokenizer.
             """
             if len(self) == 0:
                 return TimedList([])
-            
+
+
+            split_by_speaker = self.split_by_speaker()
+
+            if len(split_by_speaker) > 1:
+                logger.debug(f"Sentence splitting found {len(split_by_speaker)} speakers. Try to split last speaker's utterance")
+
 
             if sentence_splitter is None:
                 logger.warning("No sentence splitter provided, concatenating tokens")
-                return self.concatenate()
+                return split_by_speaker
 
-            full_text = self.get_text()
+            
+            last_speaker_utterance = split_by_speaker.pop(-1)
+   
+            last_speaker_sentences = run_sentence_splitter(last_speaker_utterance, sentence_splitter)
 
-            try:
-                # most tokenizers (e.g., MosesSentenceSplitter) expect a list input.
-                sentence_texts = sentence_splitter([full_text])
-            except Exception as e:   
-                try:
-                    sentence_texts = sentence_splitter(full_text)
-                except Exception as e2:
-                    raise ValueError("Tokenization failed") from e
+            return split_by_speaker + last_speaker_sentences
 
-            # Match output of sentence splitter to the input tokens
-            sentences: TimedList = TimedList([])
-            token_index = 0
 
-            for sent_text in sentence_texts:
-                sent_text = sent_text.strip()
-                if not sent_text:
-                    continue
-                sent_tokens = TimedList([])
 
-                accumulated = ""
-                # Accumulate tokens until roughly matching the length of the sentence text.
-                while token_index < len(self) and len(accumulated) < len(sent_text):
-                    token = self[token_index]
-                    accumulated = (accumulated + self.sep + token.text).strip() if accumulated else token.text
-                    sent_tokens.append(token)
-                    token_index += 1
-                if sent_tokens:
-                    sentences.append(sent_tokens.concatenate())
-            return sentences
+def run_sentence_splitter(input_sentences: 'TimedList',sentence_splitter: Callable[[str], List[str]] | Callable[[List[str]], List[str]]) -> List['TimedList']:
+    """
+    Run the sentence splitter on the transcript.
+    """
+    
+    if len(input_sentences) == 0:
+        return []
+    
+    assert isinstance(input_sentences, TimedList), "Expect a TimedList to run the sentence splitter"
+
+    full_text = input_sentences.get_text()
+
+    try:
+        # most tokenizers (e.g., MosesSentenceSplitter) expect a list input.
+        sentence_texts = sentence_splitter([full_text])
+    except Exception as e:   
+        try:
+            sentence_texts = sentence_splitter(full_text)
+        except Exception as e2:
+            raise ValueError("Tokenization failed") from e
+
+    # Match output of sentence splitter to the input tokens
+    sentences= []
+    token_index = 0
+
+    for sent_text in sentence_texts:
+        sent_text = sent_text.strip()
+        if not sent_text:
+            continue
+        sent_tokens = TimedList([],sep=input_sentences.sep)
+
+        accumulated = ""
+        # Accumulate tokens until roughly matching the length of the sentence text.
+        while token_index < len(input_sentences) and len(accumulated) < len(sent_text):
+            token = input_sentences[token_index]
+            accumulated = (accumulated + input_sentences.sep + token.text).strip() if accumulated else token.text
+            sent_tokens.append(token)
+            token_index += 1
+        if sent_tokens:
+            sentences.append(sent_tokens)
+    return sentences
+
 
 
 if __name__ == "__main__":

--- a/web/live_transcription.html
+++ b/web/live_transcription.html
@@ -373,7 +373,7 @@
                     // Check for status messages
                     if (data.type === "ready_to_stop") {
                         waitingForStop = false;
-                        console.log("Ready to stop");
+                        console.log("Ready to stop, closing WebSocket");
 
                         //Now we can close the WebSocket
                         if (websocket) {
@@ -583,8 +583,7 @@
         async function toggleRecording() {
             if (!isRecording) {
                 if (waitingForStop) {
-                    statusText.textContent = "Please wait for processing to complete...";
-                    return;
+                    return;  // Early return, UI is already updated
                 }
                 
                 try {
@@ -607,7 +606,17 @@
 
         function updateUI() {
             recordButton.classList.toggle("recording", isRecording);
-            statusText.textContent = isRecording ? "Recording..." : "Click to start transcription";
+            
+            if (waitingForStop) {
+                statusText.textContent = "Please wait for processing to complete...";
+                recordButton.disabled = true;  // Optionally disable the button while waiting
+            } else if (isRecording) {
+                statusText.textContent = "Recording...";
+                recordButton.disabled = false;
+            } else {
+                statusText.textContent = "Click to start transcription";
+                recordButton.disabled = false;
+            }
         }
 
         recordButton.addEventListener("click", toggleRecording);

--- a/web/live_transcription.html
+++ b/web/live_transcription.html
@@ -373,8 +373,9 @@
                     // Check for status messages
                     if (data.type === "ready_to_stop") {
                         waitingForStop = false;
+                        console.log("Ready to stop");
 
-                        // Only close WebSocket after processing is complete
+                        //Now we can close the WebSocket
                         if (websocket) {
                             websocket.close();
                             websocket = null;

--- a/web/live_transcription.html
+++ b/web/live_transcription.html
@@ -516,7 +516,14 @@
 
         async function stopRecording() {
             userClosing = true;
-            waitingForStop = true;  // Set the flag when stopping
+            waitingForStop = true;
+            
+            if (websocket && websocket.readyState === WebSocket.OPEN) {
+                // Send empty audio buffer as stop signal
+                const emptyBlob = new Blob([], { type: 'audio/webm' });
+                websocket.send(emptyBlob);
+                statusText.textContent = "Recording stopped. Processing final audio...";
+            }
             
             if (recorder) {
                 recorder.stop();

--- a/web/live_transcription.html
+++ b/web/live_transcription.html
@@ -388,22 +388,22 @@
                         lines = [], 
                         buffer_transcription = "", 
                         buffer_diarization = "",
-                        remaining_time_transcription = 0,
-                        remaining_time_diarization = 0
+                        transcription_lag = 0,
+                        diarization_lag = 0
                     } = data;
                     
                     renderLinesWithBuffer(
                         lines, 
                         buffer_diarization, 
                         buffer_transcription, 
-                        remaining_time_diarization,
-                        remaining_time_transcription
+                        diarization_lag,
+                        transcription_lag
                     );
                 };
             });
         }
 
-        function renderLinesWithBuffer(lines, buffer_diarization, buffer_transcription, remaining_time_diarization, remaining_time_transcription) {
+        function renderLinesWithBuffer(lines, buffer_diarization, buffer_transcription, diarization_lag, transcription_lag) {
             const linesHtml = lines.map((item, idx) => {
                 let timeInfo = "";
                 if (item.beg !== undefined && item.end !== undefined) {
@@ -414,7 +414,7 @@
                 if (item.speaker === -2) {
                     speakerLabel = `<span class="silence">Silence<span id='timeInfo'>${timeInfo}</span></span>`;
                 } else if (item.speaker == 0) {
-                    speakerLabel = `<span class='loading'><span class="spinner"></span><span id='timeInfo'>${remaining_time_diarization} second(s) of audio are undergoing diarization</span></span>`;
+                    speakerLabel = `<span class='loading'><span class="spinner"></span><span id='timeInfo'>${diarization_lag} second(s) of audio are undergoing diarization</span></span>`;
                 } else if (item.speaker == -1) {
                     speakerLabel = `<span id="speaker"><span id='timeInfo'>${timeInfo}</span></span>`;
                 } else if (item.speaker !== -1) {
@@ -423,10 +423,10 @@
 
                 let textContent = item.text;
                 if (idx === lines.length - 1) {
-                    speakerLabel += `<span class="label_transcription"><span class="spinner"></span>Transcription lag <span id='timeInfo'>${remaining_time_transcription}s</span></span>`
+                    speakerLabel += `<span class="label_transcription"><span class="spinner"></span>Transcription lag <span id='timeInfo'>${transcription_lag}s</span></span>`
                 }
                 if (idx === lines.length - 1 && buffer_diarization) {
-                    speakerLabel += `<span class="label_diarization"><span class="spinner"></span>Diarization lag<span id='timeInfo'>${remaining_time_diarization}s</span></span>`
+                    speakerLabel += `<span class="label_diarization"><span class="spinner"></span>Diarization lag<span id='timeInfo'>${diarization_lag}s</span></span>`
                     textContent += `<span class="buffer_diarization">${buffer_diarization}</span>`;
                 }
                 if (idx === lines.length - 1) {

--- a/web/live_transcription.html
+++ b/web/live_transcription.html
@@ -304,6 +304,7 @@
         let waveCanvas = document.getElementById("waveCanvas");
         let waveCtx = waveCanvas.getContext("2d");
         let animationFrame = null;
+        let waitingForStop = false;
         waveCanvas.width = 60 * (window.devicePixelRatio || 1);
         waveCanvas.height = 30 * (window.devicePixelRatio || 1);
         waveCtx.scale(window.devicePixelRatio || 1, window.devicePixelRatio || 1);
@@ -346,10 +347,16 @@
 
                 websocket.onclose = () => {
                     if (userClosing) {
-                        statusText.textContent = "WebSocket closed by user.";
+                        if (!statusText.textContent.includes("Recording stopped. Processing final audio")) { // This is a bit of a hack. We should have a better way to handle this. eg. using a status code.
+                            statusText.textContent = "Finished processing audio! Ready to record again.";
+                        }
+                        waitingForStop = false;
                     } else {
                         statusText.textContent =
                             "Disconnected from the WebSocket server. (Check logs if model is loading.)";
+                        if (isRecording) {
+                            stopRecording();
+                        }
                     }
                     userClosing = false;
                 };
@@ -363,6 +370,19 @@
                 websocket.onmessage = (event) => {
                     const data = JSON.parse(event.data);
                     
+                    // Check for status messages
+                    if (data.type === "ready_to_stop") {
+                        waitingForStop = false;
+
+                        // Only close WebSocket after processing is complete
+                        if (websocket) {
+                            websocket.close();
+                            websocket = null;
+                        }
+                        return;
+                    }
+                    
+                    // Handle normal transcription updates
                     const { 
                         lines = [], 
                         buffer_transcription = "", 
@@ -494,8 +514,10 @@
             }
         }
 
-        function stopRecording() {
+        async function stopRecording() {
             userClosing = true;
+            waitingForStop = true;  // Set the flag when stopping
+            
             if (recorder) {
                 recorder.stop();
                 recorder = null;
@@ -531,22 +553,41 @@
             timerElement.textContent = "00:00";
             startTime = null;
             
-            isRecording = false;
-
-            if (websocket) {
-                websocket.close();
-                websocket = null;
+            if (websocket && websocket.readyState === WebSocket.OPEN) {
+                try {
+                    await websocket.send(JSON.stringify({
+                        type: "stop",
+                        message: "User stopped recording"
+                    }));
+                    statusText.textContent = "Recording stopped. Processing final audio...";
+                } catch (e) {
+                    console.error("Could not send stop message:", e);
+                    statusText.textContent = "Recording stopped. Error during final audio processing.";
+                    websocket.close();
+                    websocket = null;
+                }
             }
-
+            
+            isRecording = false;
             updateUI();	
         }
 
         async function toggleRecording() {
             if (!isRecording) {
-                linesTranscriptDiv.innerHTML = "";
+                if (waitingForStop) {
+                    statusText.textContent = "Please wait for processing to complete...";
+                    return;
+                }
+                
                 try {
-                    await setupWebSocket();
-                    await startRecording();
+                    // If we have an active WebSocket that's still processing, just restart audio capture
+                    if (websocket && websocket.readyState === WebSocket.OPEN) {
+                        await startRecording();
+                    } else {
+                        // If no active WebSocket or it's closed, create new one
+                        await setupWebSocket();
+                        await startRecording();
+                    }
                 } catch (err) {
                     statusText.textContent = "Could not connect to WebSocket or access mic. Aborted.";
                     console.error(err);

--- a/web/live_transcription.html
+++ b/web/live_transcription.html
@@ -56,6 +56,10 @@
             transition: all 0.3s ease;
         }
 
+        #recordButton:disabled .shape {
+            background-color: #6e6d6d;
+        }
+
         #recordButton.recording .shape {
             border-radius: 5px;
             width: 25px;
@@ -372,14 +376,21 @@
                     
                     // Check for status messages
                     if (data.type === "ready_to_stop") {
-                        waitingForStop = false;
                         console.log("Ready to stop, closing WebSocket");
+
+                        // signal that we are not waiting for stop anymore
+                        waitingForStop = false;
+                        recordButton.disabled = false; // this should be elsewhere
+                        console.log("Record button enabled");
 
                         //Now we can close the WebSocket
                         if (websocket) {
                             websocket.close();
                             websocket = null;
                         }
+
+
+                        
                         return;
                     }
                     
@@ -583,9 +594,10 @@
         async function toggleRecording() {
             if (!isRecording) {
                 if (waitingForStop) {
+                    console.log("Waiting for stop, early return");
                     return;  // Early return, UI is already updated
                 }
-                
+                console.log("Connecting to WebSocket");
                 try {
                     // If we have an active WebSocket that's still processing, just restart audio capture
                     if (websocket && websocket.readyState === WebSocket.OPEN) {
@@ -600,6 +612,7 @@
                     console.error(err);
                 }
             } else {
+                console.log("Stopping recording");
                 stopRecording();
             }
         }
@@ -610,12 +623,15 @@
             if (waitingForStop) {
                 statusText.textContent = "Please wait for processing to complete...";
                 recordButton.disabled = true;  // Optionally disable the button while waiting
+                console.log("Record button disabled");
             } else if (isRecording) {
                 statusText.textContent = "Recording...";
                 recordButton.disabled = false;
+                console.log("Record button enabled");
             } else {
                 statusText.textContent = "Click to start transcription";
                 recordButton.disabled = false;
+                console.log("Record button enabled");
             }
         }
 

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -619,5 +619,5 @@ if __name__ == "__main__":
 
     uvicorn.run(
         "whisper_fastapi_online_server:app", host=args.host, port=args.port, reload=True,
-        log_level="info"
+        log_level=args.log_level.lower()
     )

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -239,6 +239,21 @@ async def transcription_processor(shared_state, pcm_queue, transcriber):
 
     logger.info("Transcription processor started.")
     
+    full_transcription = ""
+    
+    # TODO: simplify and use sep from TimedList
+    try:
+        sep = transcriber.asr.sep
+    except AttributeError:
+        try:
+            sep = transcriber.online.asr.sep
+        except AttributeError:
+            logger.warning("No separator found for transcription. Using default separator.' '")
+            sep = " "
+
+
+    logger.info("Transcription processor started.")
+    
     transcription_is_running = True
     while transcription_is_running:
         try:

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -86,6 +86,8 @@ args = parser.parse_args()
 logging.getLogger("whisper_streaming_custom").setLevel(logging.getLevelName(args.log_level))
 logging.getLogger("diarization").setLevel(logging.getLevelName(args.log_level))
 
+## Is not this used?
+# MIN_CHUNK_SIZE = int(args.vac_chunk_size if args.vac else args.min_chunk_size)
 
 
 SAMPLE_RATE = 16000
@@ -219,24 +221,38 @@ async def start_ffmpeg_decoder():
     )
     return process
 
-async def transcription_processor(shared_state, pcm_queue, online):
+async def transcription_processor(shared_state, pcm_queue, transcriber):
+
+    
     full_transcription = ""
-    sep = online.asr.sep
+    
+    # TODO: simplify and use sep from TimedList
+    try:
+        sep = transcriber.asr.sep
+    except AttributeError:
+        try:
+            sep = transcriber.online.asr.sep
+        except AttributeError:
+            logger.warning("No separator found for transcription. Using default separator.' '")
+            sep = " "
+
+
+    logger.info("Transcription processor started.")
     
     while True:
         try:
             pcm_array = await pcm_queue.get()
             
-            logger.info(f"{len(online.audio_buffer) / online.SAMPLING_RATE} seconds of audio will be processed by the model.")
+            logger.info(f"{len(transcriber.audio_buffer) / transcriber.SAMPLING_RATE} seconds of audio will be processed by the model.")
             
             # Process transcription
-            online.insert_audio_chunk(pcm_array)
-            new_tokens = online.process_iter()
+            transcriber.insert_audio_chunk(pcm_array)
+            new_tokens = transcriber.process_iter()
             
             if new_tokens:
                 full_transcription += new_tokens.get_text(sep=sep)
                 
-            _buffer = online.get_buffer()
+            _buffer = transcriber.get_buffer()
             buffer = _buffer.text
             end_buffer = _buffer.end if _buffer.end else (new_tokens[-1].end if new_tokens else 0)
             
@@ -396,10 +412,10 @@ async def websocket_endpoint(websocket: WebSocket):
     transcription_queue = asyncio.Queue() if args.transcription else None
     diarization_queue = asyncio.Queue() if args.diarization else None
     
-    online = None
+    transcriber = None
 
     async def restart_ffmpeg():
-        nonlocal ffmpeg_process, online, pcm_buffer
+        nonlocal ffmpeg_process, transcriber, pcm_buffer
         if ffmpeg_process:
             try:
                 ffmpeg_process.kill()
@@ -410,7 +426,7 @@ async def websocket_endpoint(websocket: WebSocket):
         pcm_buffer = bytearray()
         
         if args.transcription:
-            online = online_factory(args, asr, tokenizer)
+            transcriber = online_factory(args, asr, tokenizer)
         
         await shared_state.reset()
         logger.info("FFmpeg process started.")
@@ -418,9 +434,11 @@ async def websocket_endpoint(websocket: WebSocket):
     await restart_ffmpeg()
 
     tasks = []    
-    if args.transcription and online:
+    if args.transcription and transcriber:
         tasks.append(asyncio.create_task(
-            transcription_processor(shared_state, transcription_queue, online)))    
+            transcription_processor(shared_state, transcription_queue, transcriber)))    
+    else:
+        logger.critical("Transcription processor not started.")
     if args.diarization and diarization:
         tasks.append(asyncio.create_task(
             diarization_processor(shared_state, diarization_queue, diarization)))

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -619,5 +619,5 @@ if __name__ == "__main__":
 
     uvicorn.run(
         "whisper_fastapi_online_server:app", host=args.host, port=args.port, reload=True,
-        log_level=args.log_level.lower()
+        log_level="info"
     )

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -504,5 +504,5 @@ if __name__ == "__main__":
 
     uvicorn.run(
         "whisper_fastapi_online_server:app", host=args.host, port=args.port, reload=True,
-        log_level="info"
+        log_level=args.log_level.lower()
     )

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -22,10 +22,21 @@ def format_time(seconds):
     return str(timedelta(seconds=int(seconds)))
 
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+# Configure logging for all modules
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+
+# Set root logger level
 logging.getLogger().setLevel(logging.WARNING)
+
+
+
+
+# Configure main module logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+
+
 
 ##### LOAD ARGS #####
 
@@ -69,6 +80,13 @@ parser.add_argument(
 
 add_shared_args(parser)
 args = parser.parse_args()
+
+
+# Configure specific loggers for different modules
+logging.getLogger("whisper_streaming_custom").setLevel(logging.getLevelName(args.log_level))
+logging.getLogger("diarization").setLevel(logging.getLevelName(args.log_level))
+
+
 
 SAMPLE_RATE = 16000
 CHANNELS = 1
@@ -504,5 +522,5 @@ if __name__ == "__main__":
 
     uvicorn.run(
         "whisper_fastapi_online_server:app", host=args.host, port=args.port, reload=True,
-        log_level=args.log_level.lower()
+        log_level="info"
     )

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -216,7 +216,7 @@ async def transcription_processor(shared_state, pcm_queue, online):
             new_tokens = online.process_iter()
             
             if new_tokens:
-                full_transcription += sep.join([t.text for t in new_tokens])
+                full_transcription += new_tokens.get_text(sep=sep)
                 
             _buffer = online.get_buffer()
             buffer = _buffer.text

--- a/whisper_fastapi_online_server.py
+++ b/whisper_fastapi_online_server.py
@@ -255,21 +255,7 @@ async def start_ffmpeg_decoder():
 async def transcription_processor(shared_state, pcm_queue, transcriber):
 
     
-    full_transcription = ""
-    
-    # TODO: simplify and use sep from TimedList
-    try:
-        sep = transcriber.asr.sep
-    except AttributeError:
-        try:
-            sep = transcriber.online.asr.sep
-        except AttributeError:
-            logger.warning("No separator found for transcription. Using default separator.' '")
-            sep = " "
 
-
-    logger.info("Transcription processor started.")
-    
     full_transcription = ""
     
     # TODO: simplify and use sep from TimedList

--- a/whisper_streaming_custom/online_asr.py
+++ b/whisper_streaming_custom/online_asr.py
@@ -87,8 +87,7 @@ class HypothesisBuffer:
         """
         Remove tokens (from the beginning) that have ended before `time`.
         """
-        while self.committed_in_buffer and self.committed_in_buffer[0].end <= time:
-            self.committed_in_buffer.pop(0)
+        _,self.committed_in_buffer= self.committed_in_buffer.split_at(time, edge_word_goes_left=False)
 
 
 

--- a/whisper_streaming_custom/online_asr.py
+++ b/whisper_streaming_custom/online_asr.py
@@ -220,13 +220,13 @@ class OnlineASRProcessor:
 
         sentences = self.committed.split_to_sentences(self.tokenize)
         for sentence in sentences:
-            logger.debug(f"\tSentence: {sentence.text}")
+            logger.debug(f"\tSentence: {sentence}")
         if len(sentences) < 2:
             return
         # Keep the last two sentences.
         while len(sentences) > 2:
             sentences.pop(0)
-        chunk_time = sentences[-2].end
+        chunk_time = sentences[-2][-1].end
         logger.debug(f"--- Sentence chunked at {chunk_time:.2f}")
         self.chunk_at(chunk_time)
 

--- a/whisper_streaming_custom/online_asr.py
+++ b/whisper_streaming_custom/online_asr.py
@@ -279,6 +279,8 @@ class OnlineASRProcessor:
         remaining_tokens = self.transcript_buffer.buffer
         logger.debug(f"Final non-committed transcript: {remaining_tokens}")
         self.buffer_time_offset += len(self.audio_buffer) / self.SAMPLING_RATE
+        self.audio_buffer = np.array([], dtype=np.float32)
+
         return remaining_tokens
 
 
@@ -335,6 +337,10 @@ class VACOnlineASRProcessor:
             if "start" in res and "end" not in res:
                 self.status = "voice"
                 send_audio = self.audio_buffer[frame:]
+
+                if len(self.online.audio_buffer) > 0:
+                    logger.critical(f"Re-init translator, when previous audio_buffer is not finished!")
+                
                 self.online.init(offset=(frame + self.buffer_offset) / self.SAMPLING_RATE)
                 self.online.insert_audio_chunk(send_audio)
                 self.current_online_chunk_buffer_size += len(send_audio)


### PR DESCRIPTION
Related to #78 

Stoping on client side sends empty dataset. This is interpreted as a stop signal.
1. Main loop is exited
2. audio recording is stoped (Record button is grayed out, and deactivated)
3. Send stop signal to transcription
4. If finished send stop signal to diarization
5. If finished send ready_to_stop to client.

Transcription and diarization are finished correctly but the formating of the speaker is not finished. I don't understand why. 

Without diarization works.

TODO:
- [ ] Finalize formating of speaker
- [ ] Restart recording and append. For now restart recording clears previous transcipt
- [ ] Remove spinner

# Other fixes included
- Fix delay calculations for diarization based oin actual seconds recorded
