### PR TITLE
fix port for WS link; use correct HF build arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ To deploy WhisperLiveKit in production:
    - Ensure WebSocket connection points to your server's address
 
 3. **Nginx Configuration** (recommended for production):
-   ```nginx
+```nginx
    server {
        listen 80;
        server_name your-domain.com;
@@ -324,7 +324,7 @@ docker start -i whisperlivekit-base
 - `--build-arg` Options:
   - `EXTRAS="whisper-timestamped"` - Add extras to the image's installation (no spaces). Remember to set necessary container options!
   - `HF_PRECACHE_DIR="./.cache/"` - Pre-load a model cache for faster first-time start
-  - `HF_TOKEN="./token"` - Add your Hugging Face Hub access token to download gated models
+  - `HF_TKN_FILE="./token"` - Add your Hugging Face Hub access token to download gated models
 
 ## 🔮 Use Cases
 

--- a/whisperlivekit/web/live_transcription.html
+++ b/whisperlivekit/web/live_transcription.html
@@ -321,7 +321,7 @@
         const timerElement = document.querySelector(".timer");
 
         const host = window.location.hostname || "localhost";
-        const port = window.location.port || "8000";
+        const port = window.location.port;
         const protocol = window.location.protocol === "https:" ? "wss" : "ws";
         const defaultWebSocketUrl = `${protocol}://${host}:${port}/asr`;
         websocketInput.value = defaultWebSocketUrl;


### PR DESCRIPTION
# Port

Currently if I put reverse-proxy or ingress for this service, such as https://whisper.example.com/

the URL for websocket will have port 8000, which is incorrect.
This PR fixes that. Now in case if port 8000 / any other ports - that port still will be used. But in case of default ports  (such as 443) - it will be omitted.

# build arg

`HF_TKN_FILE` is used in Dockerfile.

But readme was saying `HF_TOKEN`