### PR TITLE
Ensure diarization_queue receives only latest PCM chunk

### DIFF
--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -192,12 +192,6 @@ class AudioProcessor:
                         continue
                     
                 self.pcm_buffer.extend(chunk)
-                        
-                # Send to diarization if enabled
-                if self.args.diarization and self.diarization_queue:
-                    await self.diarization_queue.put(
-                        self.convert_pcm_to_float(self.pcm_buffer).copy()
-                    )
 
                 # Process when enough data
                 if len(self.pcm_buffer) >= self.bytes_per_sec:
@@ -214,7 +208,11 @@ class AudioProcessor:
                     # Send to transcription if enabled
                     if self.args.transcription and self.transcription_queue:
                         await self.transcription_queue.put(pcm_array.copy())
-                    
+
+                    # Send to diarization if enabled
+                    if self.args.diarization and self.diarization_queue:
+                        await self.diarization_queue.put(pcm_array.copy())
+
                     # Sleep if no processing is happening
                     if not self.args.transcription and not self.args.diarization:
                         await asyncio.sleep(0.1)


### PR DESCRIPTION
## Problem
This PR fixes a bug where `diarization_queue` was incorrectly sent the entire `self.pcm_buffer` on every iteration, instead of just the latest chunk. This causes `diarization_queue` to receive increasingly overlapping audio, which degrades diarization accuracy and performance.

## Fix
The fix is to use the already-prepared `pcm_array` (for transcription) and send the same copy to both `transcription_queue` and `diarization_queue`. 