### PR TITLE
Fix: Exponentially growing simulstreaming silence timer

### DIFF
--- a/whisperlivekit/simul_whisper/backend.py
+++ b/whisperlivekit/simul_whisper/backend.py
@@ -77,7 +77,7 @@ class SimulStreamingOnlineProcessor:
         else:
             self.process_iter(is_last=True) #we want to totally process what remains in the buffer.
             self.model.refresh_segment(complete=True)
-            self.global_time_offset += silence_duration + offset
+            self.global_time_offset = silence_duration + offset
 
 
         


### PR DESCRIPTION
Fixes https://github.com/QuentinFuxa/WhisperLiveKit/issues/195, a bug where, after the user stops speaking, the “silence” timer grows much faster than real time and can jump to very large values. And then subsequent speech lines would inherit incorrect timestamps.

#### Root cause
In simulstreaming, after a long silence we refreshed the segment and then updated global_time_offset using += silence_duration + offset. Because offset is an absolute time, adding it repeatedly across long-silence transitions caused timestamps to drift and grow. The UI displays beg/end from these timestamps, so “Silence …” labels and subsequent lines appeared with inflated times.

<img width="317" height="662" alt="image" src="https://github.com/user-attachments/assets/7b6c2d07-608e-4f48-a95f-8b6c782a1370" />

#### Fix
We can just set the absolute offset after long silence rather than accumulating it.