### PR TITLE
Fix scrolling UX with sticky header controls

### DIFF
--- a/whisperlivekit/web/live_transcription.css
+++ b/whisperlivekit/web/live_transcription.css
@@ -74,10 +74,13 @@
 
 body {
   font-family: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  margin: 20px;
+  margin: 0;
   text-align: center;
   background-color: var(--bg);
   color: var(--text);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Record button */
@@ -168,9 +171,18 @@ body {
 }
 
 #status {
-  margin-top: 20px;
+  margin-top: 15px;
   font-size: 16px;
   color: var(--text);
+  margin-bottom: 0;
+}
+
+.header-container {
+  position: sticky;
+  top: 0;
+  background-color: var(--bg);
+  z-index: 100;
+  padding: 20px;
 }
 
 /* Settings */
@@ -179,7 +191,6 @@ body {
   justify-content: center;
   align-items: center;
   gap: 15px;
-  margin-top: 20px;
 }
 
 .settings {
@@ -297,9 +308,21 @@ label {
   border-radius: 999px;
 }
 
+.transcript-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.transcript-container::-webkit-scrollbar {
+  display: none;
+}
+
 /* Transcript area */
 #linesTranscript {
-  margin: 20px auto;
+  margin: 0 auto;
   max-width: 700px;
   text-align: left;
   font-size: 16px;
@@ -407,6 +430,10 @@ label {
 
 /* for smaller screens */
 @media (max-width: 768px) {
+  .header-container {
+    padding: 15px;
+  }
+  
   .settings-container {
     flex-direction: column;
     gap: 10px;
@@ -430,11 +457,15 @@ label {
   .theme-selector-container {
     margin-top: 10px;
   }
+  
+  .transcript-container {
+    padding: 15px;
+  }
 }
 
 @media (max-width: 480px) {
-  body {
-    margin: 10px;
+  .header-container {
+    padding: 10px;
   }
   
   .settings {
@@ -456,5 +487,9 @@ label {
   .segmented img {
     width: 14px;
     height: 14px;
+  }
+  
+  .transcript-container {
+    padding: 10px;
   }
 }

--- a/whisperlivekit/web/live_transcription.html
+++ b/whisperlivekit/web/live_transcription.html
@@ -9,63 +9,63 @@
 </head>
 
 <body>
-    <div class="settings-container">
-        <button id="recordButton">
-            <div class="shape-container">
-                <div class="shape"></div>
-            </div>
-            <div class="recording-info">
-                <div class="wave-container">
-                    <canvas id="waveCanvas"></canvas>
+    <div class="header-container">
+        <div class="settings-container">
+            <button id="recordButton">
+                <div class="shape-container">
+                    <div class="shape"></div>
                 </div>
-                <div class="timer">00:00</div>
-            </div>
-        </button>
+                <div class="recording-info">
+                    <div class="wave-container">
+                        <canvas id="waveCanvas"></canvas>
+                    </div>
+                    <div class="timer">00:00</div>
+                </div>
+            </button>
 
-        <div class="settings">
-            <div class="field">
-                <label for="websocketInput">Websocket URL</label>
-                <input id="websocketInput" type="text" placeholder="ws://host:port/asr" />
-            </div>
+            <div class="settings">
+                <div class="field">
+                    <label for="websocketInput">Websocket URL</label>
+                    <input id="websocketInput" type="text" placeholder="ws://host:port/asr" />
+                </div>
 
-            <div class="field">
-                <label id="microphoneSelectLabel" for="microphoneSelect">Select Microphone</label>
-                <select id="microphoneSelect">
-                    <option value="">Default Microphone</option>
-                </select>
-            </div>
+                <div class="field">
+                    <label id="microphoneSelectLabel" for="microphoneSelect">Select Microphone</label>
+                    <select id="microphoneSelect">
+                        <option value="">Default Microphone</option>
+                    </select>
+                </div>
 
-            <div class="theme-selector-container">
-                <div class="segmented" role="radiogroup" aria-label="Theme selector">
-                    <input type="radio" id="theme-system" name="theme" value="system" />
-                    <label for="theme-system" title="System">
-                        <img src="/web/src/system_mode.svg" alt="" />
-                        <span>System</span>
-                    </label>
+                <div class="theme-selector-container">
+                    <div class="segmented" role="radiogroup" aria-label="Theme selector">
+                        <input type="radio" id="theme-system" name="theme" value="system" />
+                        <label for="theme-system" title="System">
+                            <img src="/web/src/system_mode.svg" alt="" />
+                            <span>System</span>
+                        </label>
 
-                    <input type="radio" id="theme-light" name="theme" value="light" />
-                    <label for="theme-light" title="Light">
-                        <img src="/web/src/light_mode.svg" alt="" />
-                        <span>Light</span>
-                    </label>
+                        <input type="radio" id="theme-light" name="theme" value="light" />
+                        <label for="theme-light" title="Light">
+                            <img src="/web/src/light_mode.svg" alt="" />
+                            <span>Light</span>
+                        </label>
 
-                    <input type="radio" id="theme-dark" name="theme" value="dark" />
-                    <label for="theme-dark" title="Dark">
-                        <img src="/web/src/dark_mode.svg" alt="" />
-                        <span>Dark</span>
-                    </label>
+                        <input type="radio" id="theme-dark" name="theme" value="dark" />
+                        <label for="theme-dark" title="Dark">
+                            <img src="/web/src/dark_mode.svg" alt="" />
+                            <span>Dark</span>
+                        </label>
+                    </div>
                 </div>
             </div>
-
         </div>
+        
+        <p id="status"></p>
     </div>
+
+    <div class="transcript-container">
+        <div id="linesTranscript"></div>
     </div>
-
-
-
-    <p id="status"></p>
-
-    <div id="linesTranscript"></div>
 
     <script src="/web/live_transcription.js"></script>
 </body>

--- a/whisperlivekit/web/live_transcription.js
+++ b/whisperlivekit/web/live_transcription.js
@@ -373,7 +373,10 @@ function renderLinesWithBuffer(
     .join("");
 
   linesTranscriptDiv.innerHTML = linesHtml;
-  window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+  const transcriptContainer = document.querySelector('.transcript-container');
+  if (transcriptContainer) {
+    transcriptContainer.scrollTo({ top: transcriptContainer.scrollHeight, behavior: "smooth" });
+  }
 }
 
 function updateTimer() {


### PR DESCRIPTION
During transcription, the page auto-scrolls down as new updates are received. When you try to scroll back up to access recording controls, the page scrolls back down, making controls inaccessible. 

### Proposed Solution
- Make recording controls stick to the top - this keeps them always accessible
- Create a transcript container which auto scrolls like before 

### Before
<img src="https://github.com/user-attachments/assets/7fd8daf7-5665-4c50-9f22-4687235b772c" width="480px" height="277.5px" />
<img src="https://github.com/user-attachments/assets/aab3481c-b249-43a1-813f-05bcc601a148" width="480px" height="277.5px" />

### After
<img src="https://github.com/user-attachments/assets/fa8fed51-bbca-471c-9b1d-1c758ee5d3a3" width="480px" height="277.5px" />
