### PR TITLE
docs: add vram usage for large-v3-turbo

### DIFF
--- a/available_models.md
+++ b/available_models.md
@@ -58,6 +58,7 @@
 - `small`: ~2GB VRAM
 - `medium`: ~5GB VRAM
 - `large`: ~10GB VRAM
+- `large‑v3‑turbo`: ~6GB VRAM
 
 **Audio Quality Impact**:
 - Clean, clear audio: smaller models may suffice


### PR DESCRIPTION
The `Hardware Requirements` section in `available_models.md` was missing the VRAM requirement for the `large-v3-turbo` model.

This PR adds the missing requirement, based on the details provided in the [openai/whisper README](https://github.com/openai/whisper?tab=readme-ov-file#available-models-and-languages).

