### PR TITLE
Fix: simulstreaming preload model count argument in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The rest I don't recommend. But below are your options.
 | `--static-init-prompt` | Static prompt that doesn't scroll | `None` |
 | `--max-context-tokens` | Maximum context tokens | `None` |
 | `--model-path` | Direct path to .pt model file. Download it if not found | `./base.pt` |
-| `--preloaded-model-count` | Optional. Number of models to preload in memory to speed up loading (set up to the expected number of concurrent users) | `1` |
+| `--preload-model-count` | Optional. Number of models to preload in memory to speed up loading (set up to the expected number of concurrent users) | `1` |
 
 
 | WhisperStreaming backend options | Description | Default |

--- a/whisperlivekit/parse_args.py
+++ b/whisperlivekit/parse_args.py
@@ -269,10 +269,10 @@ def parse_args():
     )
     
     simulstreaming_group.add_argument(
-        "--preloaded_model_count",
+        "--preload-model-count",
         type=int,
         default=1,
-        dest="preloaded_model_count",
+        dest="preload_model_count",
         help="Optional. Number of models to preload in memory to speed up loading (set up to the expected number of concurrent instances).",
     )
 


### PR DESCRIPTION
This PR fixes the simulstreaming model preloading flag so it works as intended.

#### Root Cause

The CLI defined the argument as `--preloaded_model_count` (with `ed`), while `core.py` passed `preload_model_count` to simulstreaming. This mismatch caused the flag to get ignored.

#### Fix

Renamed the CLI argument in `parse_args.py` to `--preload-model-count` (no `ed`) to align with `core.py` and updated README.
