### PR TITLE
Fix type error when setting encoder_feature in simul_whisper->infer for faster whisper encoder

### DIFF
--- a/whisperlivekit/simul_whisper/simul_whisper.py
+++ b/whisperlivekit/simul_whisper/simul_whisper.py
@@ -409,9 +409,12 @@ class PaddedAlignAttWhisper:
             mel_padded_2 = self.fw_feature_extractor(waveform=input_segments.numpy(), padding=N_SAMPLES)[None, :]
             mel = fw_pad_or_trim(mel_padded_2, N_FRAMES, axis=-1)
             encoder_feature_ctranslate = self.fw_encoder.encode(mel)
-            if type(encoder_feature_ctranslate).__module__ == 'ctranslate2._ext':
+            if self.device == 'cpu': #it seems that on gpu, passing StorageView to torch.as_tensor fails and wrapping in the array works
                 encoder_feature_ctranslate = np.array(encoder_feature_ctranslate)
-            encoder_feature = torch.as_tensor(encoder_feature_ctranslate, device=self.device)
+            try:
+                encoder_feature = torch.as_tensor(encoder_feature_ctranslate, device=self.device)
+            except TypeError: # Normally the cpu condition should prevent having exceptions, but just in case:
+                encoder_feature = torch.as_tensor(np.array(encoder_feature_ctranslate), device=self.device)
         else:
             # mel + padding to 30s
             mel_padded = log_mel_spectrogram(input_segments, n_mels=self.model.dims.n_mels, padding=N_SAMPLES, 

--- a/whisperlivekit/simul_whisper/simul_whisper.py
+++ b/whisperlivekit/simul_whisper/simul_whisper.py
@@ -408,7 +408,7 @@ class PaddedAlignAttWhisper:
             content_mel_len = int(audio_length_seconds * 100)//2      
             mel_padded_2 = self.fw_feature_extractor(waveform=input_segments.numpy(), padding=N_SAMPLES)[None, :]
             mel = fw_pad_or_trim(mel_padded_2, N_FRAMES, axis=-1)
-            encoder_feature_ctranslate = np.array(self.fw_encoder.encode(mel))
+            encoder_feature_ctranslate = self.fw_encoder.encode(mel)
             encoder_feature = torch.as_tensor(encoder_feature_ctranslate, device=self.device)
         else:
             # mel + padding to 30s

--- a/whisperlivekit/simul_whisper/simul_whisper.py
+++ b/whisperlivekit/simul_whisper/simul_whisper.py
@@ -409,6 +409,8 @@ class PaddedAlignAttWhisper:
             mel_padded_2 = self.fw_feature_extractor(waveform=input_segments.numpy(), padding=N_SAMPLES)[None, :]
             mel = fw_pad_or_trim(mel_padded_2, N_FRAMES, axis=-1)
             encoder_feature_ctranslate = self.fw_encoder.encode(mel)
+            if type(encoder_feature_ctranslate).__module__ == 'ctranslate2._ext':
+                encoder_feature_ctranslate = np.array(encoder_feature_ctranslate)
             encoder_feature = torch.as_tensor(encoder_feature_ctranslate, device=self.device)
         else:
             # mel + padding to 30s


### PR DESCRIPTION
self.fw_encoder.encode(mel) returns a ctranslate2.StorageView meant to be passed directly as an argument to torch.as_tensor(). Wrapping it in an np.array gives:

`TypeError: can’t convert np.ndarray of type numpy.object_. The only supported types are: float64, float32, float16, int64, int32, int16, int8, uint8, and bool.`

Passing the StorageView directly fixes this.

Best regards
Alexander