### PR TITLE
Fix warmup file behavior

### DIFF
--- a/whisperlivekit/core.py
+++ b/whisperlivekit/core.py
@@ -120,7 +120,7 @@ class TranscriptionEngine:
 
             else:
                 self.asr, self.tokenizer = backend_factory(self.args)
-            warmup_asr(self.asr, self.args.warmup_file) #for simulstreaming, warmup should be done in the online class not here
+                warmup_asr(self.asr, self.args.warmup_file) #for simulstreaming, warmup should be done in the online class not here
 
         if self.args.diarization:
             if self.args.diarization_backend == "diart":

--- a/whisperlivekit/core.py
+++ b/whisperlivekit/core.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from .whisper_streaming_custom.whisper_online import backend_factory
     from .whisper_streaming_custom.online_asr import OnlineASRProcessor
-from whisperlivekit.warmup import warmup_asr, warmup_online
+from whisperlivekit.warmup import warmup_asr
 from argparse import Namespace
 import sys
 
@@ -155,7 +155,6 @@ def online_factory(args, asr, tokenizer, logfile=sys.stderr):
             asr,
             logfile=logfile,
         )
-        # warmup_online(online, args.warmup_file)
     else:
         online = OnlineASRProcessor(
             asr,

--- a/whisperlivekit/parse_args.py
+++ b/whisperlivekit/parse_args.py
@@ -20,7 +20,7 @@ def parse_args():
         help="""
         The path to a speech audio wav file to warm up Whisper so that the very first chunk processing is fast.
         If not set, uses https://github.com/ggerganov/whisper.cpp/raw/master/samples/jfk.wav.
-        If False, no warmup is performed.
+        If empty, no warmup is performed.
         """,
     )
 

--- a/whisperlivekit/warmup.py
+++ b/whisperlivekit/warmup.py
@@ -6,57 +6,54 @@ logger = logging.getLogger(__name__)
 def load_file(warmup_file=None, timeout=5):
     import os
     import tempfile
+    import urllib.request
     import librosa
-        
+
+    if warmup_file == "":
+        logger.info(f"Skipping warmup.")
+        return None
+
+    # Download JFK sample if not already present
     if warmup_file is None:
-        # Download JFK sample if not already present
         jfk_url = "https://github.com/ggerganov/whisper.cpp/raw/master/samples/jfk.wav"
         temp_dir = tempfile.gettempdir()
         warmup_file = os.path.join(temp_dir, "whisper_warmup_jfk.wav")
-        
-        if not os.path.exists(warmup_file):
-            logger.debug(f"Downloading warmup file from {jfk_url}")
-            print(f"Downloading warmup file from {jfk_url}")
-            import time
-            import urllib.request
-            import urllib.error
-            import socket
-            
-            original_timeout = socket.getdefaulttimeout()
-            socket.setdefaulttimeout(timeout)
-            
-            start_time = time.time()
+        if not os.path.exists(warmup_file) or os.path.getsize(warmup_file) == 0:
             try:
-                urllib.request.urlretrieve(jfk_url, warmup_file)
-                logger.debug(f"Download successful in {time.time() - start_time:.2f}s")
-            except (urllib.error.URLError, socket.timeout) as e:
-                logger.warning(f"Download failed: {e}. Proceeding without warmup.")
+                logger.debug(f"Downloading warmup file from {jfk_url}")
+                with urllib.request.urlopen(jfk_url, timeout=timeout) as r, open(warmup_file, "wb") as f:
+                    f.write(r.read())
+            except Exception as e:
+                logger.warning(f"Warmup file download failed: {e}.")
                 return None
-            finally:
-                socket.setdefaulttimeout(original_timeout)
-    elif not warmup_file:
-        return None 
-    
-    if not warmup_file or not os.path.exists(warmup_file) or os.path.getsize(warmup_file) == 0:
-        logger.warning(f"Warmup file {warmup_file} invalid or missing.")
+
+    # Validate file and load
+    if not os.path.exists(warmup_file) or os.path.getsize(warmup_file) == 0:
+        logger.warning(f"Warmup file {warmup_file} is invalid or missing.")
         return None
-    
+
     try:
-        audio, sr = librosa.load(warmup_file, sr=16000)
+        audio, _ = librosa.load(warmup_file, sr=16000)
+        return audio
     except Exception as e:
-        logger.warning(f"Failed to load audio file: {e}")
+        logger.warning(f"Failed to load warmup file: {e}")
         return None
-    return audio
 
 def warmup_asr(asr, warmup_file=None, timeout=5):
     """
     Warmup the ASR model by transcribing a short audio file.
     """
-    audio = load_file(warmup_file=None, timeout=5)
+    audio = load_file(warmup_file=warmup_file, timeout=timeout)
+    if audio is None:
+        logger.warning("Warmup file unavailable. Skipping ASR warmup.")
+        return
     asr.transcribe(audio)
-    logger.info("ASR model is warmed up")
+    logger.info("ASR model is warmed up.")
     
 def warmup_online(online, warmup_file=None, timeout=5):
-    audio = load_file(warmup_file=None, timeout=5)
+    audio = load_file(warmup_file=warmup_file, timeout=timeout)
+    if audio is None:
+        logger.warning("Warmup file unavailable. Skipping online warmup.")
+        return
     online.warmup(audio)
-    logger.warning("ASR is warmed up")
+    logger.info("Online processor is warmed up.")

--- a/whisperlivekit/warmup.py
+++ b/whisperlivekit/warmup.py
@@ -49,11 +49,3 @@ def warmup_asr(asr, warmup_file=None, timeout=5):
         return
     asr.transcribe(audio)
     logger.info("ASR model is warmed up.")
-    
-def warmup_online(online, warmup_file=None, timeout=5):
-    audio = load_file(warmup_file=warmup_file, timeout=timeout)
-    if audio is None:
-        logger.warning("Warmup file unavailable. Skipping online warmup.")
-        return
-    online.warmup(audio)
-    logger.info("Online processor is warmed up.")


### PR DESCRIPTION
This PR fixes the `--warmup-file` handling.

#### Root Cause

1. The `warmup_file` parameter was set to `None` in `warmup_asr` and `warmup_online` functions in `warmup.py`, causing custom warmup files to be ignored for backends like faster-whisper.
2. Simulstreaming handles its warmup on its own, which made calling `warmup_asr` inside `core.py` redundant - even though its (SimulStreamingASR) `transcribe` didn't do any duplicate warmup , it would load the jfk warmup file unnecessarily. 
3. The CLI help text mentioned that warmup file could be set to False for no warmup, but its a string arg and not boolean, so the `False` check inside `load_file` didnt work. 


#### Fix
Pass the `warmup_file` to the `load_file` function.
Dont call `warmup_asr` for simulstreaming backend - moved it inside `else`.
Replaced manual socket timeout management with `urllib.request.urlopen()` using built-in timeout parameter.
Let warmup file be set to empty string for no warmup and updated the cli help text for the same. 

So now

```
# Default warmup (downloads jfk.wav)
whisperlivekit-server --model large-v3

# Custom warmup file
whisperlivekit-server --model large-v3 --warmup-file /path/to/audio.wav

# No warmup
whisperlivekit-server --model large-v3 --warmup-file ""
```

#### Testing

Tested all 3 cases - default warmup (with jfk.wav), custom warmup file and no warmup in both simulstreaming and faster-whisper backend. 

