### PR TITLE
fix: remove duplicate os import from simul_whisper

### DIFF
--- a/whisperlivekit/simul_whisper/simul_whisper.py
+++ b/whisperlivekit/simul_whisper/simul_whisper.py
@@ -13,7 +13,6 @@ from .whisper.timing import median_filter
 from .whisper.decoding import GreedyDecoder, BeamSearchDecoder, SuppressTokens, detect_language
 from .beam import BeamPyTorchInference
 from .eow_detection import fire_at_boundary, load_cif
-import os
 from time import time
 from .token_buffer import TokenBuffer
 


### PR DESCRIPTION
### Summary
Removed duplicate import os statement to clean up imports and improve code quality.

### Changes
- Consolidated duplicate os import statements into a single import
- No functional changes to the code

### Additional Notes
This is a minor cleanup that removes redundant import statements without affecting any functionality. The change improves code maintainability and follows Python best practices for import organization.