### PR TITLE
fix wss for reverse proxying

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ async def websocket_endpoint(websocket: WebSocket):
 | `--port` | Server port | `8000` |
 | `--ssl-certfile` | Path to the SSL certificate file (for HTTPS support) | `None` |
 | `--ssl-keyfile` | Path to the SSL private key file (for HTTPS support) | `None` |
+| `--forwarded-allow-ips` | Ip or Ips allowed to reverse proxy the whisperlivekit-server. Supported types are  IP Addresses (e.g. 127.0.0.1), IP Networks (e.g. 10.100.0.0/16), or Literals (e.g. /path/to/socket.sock) | `None` |
 | `--pcm-input` | raw PCM (s16le) data is expected as input and FFmpeg will be bypassed. Frontend will use AudioWorklet instead of MediaRecorder | `False` |
 
 | Translation options | Description | Default |

--- a/whisperlivekit/basic_server.py
+++ b/whisperlivekit/basic_server.py
@@ -118,6 +118,8 @@ def main():
 
     if ssl_kwargs:
         uvicorn_kwargs = {**uvicorn_kwargs, **ssl_kwargs}
+    if args.forwarded_allow_ips:
+        uvicorn_kwargs = { **uvicorn_kwargs, "forwarded_allow_ips" : args.forwarded_allow_ips }
 
     uvicorn.run(**uvicorn_kwargs)
 

--- a/whisperlivekit/parse_args.py
+++ b/whisperlivekit/parse_args.py
@@ -175,6 +175,7 @@ def parse_args():
     )
     parser.add_argument("--ssl-certfile", type=str, help="Path to the SSL certificate file.", default=None)
     parser.add_argument("--ssl-keyfile", type=str, help="Path to the SSL private key file.", default=None)
+    parser.add_argument("--forwarded-allow-ips", type=str, help="Allowed ips for reverse proxying.", default=None)
     parser.add_argument(
         "--pcm-input",
         action="store_true",

--- a/whisperlivekit/web/live_transcription.js
+++ b/whisperlivekit/web/live_transcription.js
@@ -178,14 +178,13 @@ function fmt1(x) {
 }
 
 let host, port, protocol;
-
+port = 8000;
 if (isExtension) {
     host = "localhost";
-    port = 8000;
     protocol = "ws";
 } else {
     host = window.location.hostname || "localhost";
-    port = window.location.port || 8000;
+    port = window.location.port;
     protocol = window.location.protocol === "https:" ? "wss" : "ws";
 }
 const defaultWebSocketUrl = `${protocol}://${host}${port ? ":" + port : ""}/asr`;


### PR DESCRIPTION
wss won't work behind a reverse proxy (although direct connection works). To properly set up client and protocol, uvicorn needs to have set the parameter forwarded-allow-ips.

This PR exposes it downstreams to the whisperlivekit-server

From [the docs](https://uvicorn.dev/deployment/#running-gunicorn-worker):

```
Proxies and Forwarded Headers[¶](https://uvicorn.dev/deployment/#proxies-and-forwarded-headers)
When running an application behind one or more proxies, certain information about the request is lost. To avoid this most proxies will add headers containing this information for downstream servers to read.

Uvicorn currently supports the following headers:

X-Forwarded-For ([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For))
X-Forwarded-Proto([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto))
Uvicorn can use these headers to correctly set the client and protocol in the request. However as anyone can set these headers you must configure which "clients" you will trust to have set them correctly.

Uvicorn can be configured to trust IP Addresses (e.g. 127.0.0.1), IP Networks (e.g. 10.100.0.0/16), or Literals (e.g. /path/to/socket.sock). When running from CLI these are configured using --forwarded-allow-ips.

Only trust clients you can actually trust!

...
```