### PR TITLE
fix(whisper/tokenizer): prevent IndexError from crashing multilingual…

### DIFF
--- a/whisperlivekit/whisper/tokenizer.py
+++ b/whisperlivekit/whisper/tokenizer.py
@@ -296,10 +296,15 @@ class Tokenizer:
             current_tokens.append(token)
             decoded = self.decode_with_timestamps(current_tokens)
 
-            if (
-                replacement_char not in decoded
-                or decoded_full[unicode_offset + decoded.index(replacement_char)]
-                == replacement_char
+            try:
+                replacement_char_index = decoded.index(replacement_char)
+                replacement_char_index += unicode_offset
+            except ValueError:
+                replacement_char_index = None
+
+            if replacement_char_index is None or (
+                replacement_char_index < len(decoded_full)
+                and decoded_full[replacement_char_index] == replacement_char
             ):
                 words.append(decoded)
                 word_tokens.append(current_tokens)


### PR DESCRIPTION
## Fix: Prevent `IndexError` during Multilingual Streaming (`split_tokens_on_unicode`)

### Description
This PR addresses a critical bug that causes the transcription server to crash with an `IndexError: string index out of range` when streaming continuous audio, particularly in languages that utilize multi-byte UTF-8 characters like Cantonese (`yue`), Japanese, and Mandarin.

### Root Cause
The crash originates from a known edge case in the underlying OpenAI Whisper tokenizer (`whisper/tokenizer.py`):
Whisper uses a byte-level BPE tokenizer. When a 3-byte character (like a Chinese or Japanese character) is cut off at the exact boundary of an audio chunk, the model outputs incomplete bytes (e.g., just the first 1 or 2 bytes).

When Python attempts to decode these incomplete sequences, it squashes consecutive invalid bytes into a single Unicode replacement character (`\ufffd`). The `split_tokens_on_unicode` function loops through tokens individually and maps them to an offset in the fully decoded string. Because Python compressed multiple bytes into one replacement character, the string is now artificially shorter than the offset math expects. It then throws an `IndexError: string index out of range`.

### Changes Made
* **Fix `IndexError` in `whisper/tokenizer.py`:** Ported the upstream fix from SYSTRAN/faster-whisper#111 to add a strict bounds check inside `split_tokens_on_unicode`. It now safely verifies `unicode_offset + decoded.index(replacement_char) < len(decoded_full)` before attempting to index the string, allowing the incomplete bytes to be safely caught and handled in the next stream chunk.