### PR TITLE
Fix VAD swallowing short silence boundaries

### DIFF
--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -791,16 +791,26 @@ class AudioProcessor:
         for event in vad_events:
             if "start" in event and self.current_silence:
                 start_sample = int(event["start"])
-                start_offset = max(0, min(num_samples, start_sample - chunk_sample_start))
-                await self._end_silence(at_sample=start_sample)
+                # Clamp the start sample to the current chunk boundaries.
+                # This ensures we don't retrospectively end a silence period
+                # before the current chunk, preventing negative offsets and
+                # ensuring all active audio in the current chunk is captured.
+                start_sample_eff = max(chunk_sample_start, min(chunk_sample_end, start_sample))
+                start_offset = start_sample_eff - chunk_sample_start
+                await self._end_silence(at_sample=start_sample_eff)
                 last_offset = start_offset
 
             if "end" in event and not self.current_silence:
                 end_sample = int(event["end"])
-                end_offset = max(0, min(num_samples, end_sample - chunk_sample_start))
+                # Clamp the end sample to the current chunk boundaries.
+                # This prevents double-counting the VAD delay overlap, ensuring
+                # the sum of active audio and silence durations strictly equals
+                # the physical stream duration, thereby eliminating timestamp drift.
+                end_sample_eff = max(chunk_sample_start, min(chunk_sample_end, end_sample))
+                end_offset = end_sample_eff - chunk_sample_start
                 if end_offset > last_offset:
                     await self._enqueue_active_audio(pcm_array[last_offset:end_offset])
-                await self._begin_silence(at_sample=end_sample)
+                await self._begin_silence(at_sample=end_sample_eff)
                 last_offset = end_offset
 
         if not self.current_silence and last_offset < num_samples:

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -789,24 +789,42 @@ class AudioProcessor:
         chunk_sample_start = self.total_pcm_samples
         chunk_sample_end = chunk_sample_start + num_samples
 
-        res = None
+        vad_events = []
         if self.args.vac:
-            res = self.vac(pcm_array)
+            vad_events = self.vac(pcm_array)
 
-        if res is not None:
-            if "start" in res and self.current_silence:
-                await self._end_silence(at_sample=res.get("start"))
+        active_slice_start = 0 if not self.current_silence else None
+        for event in vad_events:
+            if "start" in event and self.current_silence:
+                start_sample = event.get("start")
+                await self._end_silence(at_sample=start_sample)
+                if start_sample is None:
+                    active_slice_start = 0
+                else:
+                    active_slice_start = max(
+                        0,
+                        min(int(start_sample - chunk_sample_start), num_samples),
+                    )
 
-            if "end" in res and not self.current_silence:
-                pre_silence_chunk = self._slice_before_silence(
-                    pcm_array, chunk_sample_start, res.get("end")
-                )
-                if pre_silence_chunk is not None and pre_silence_chunk.size > 0:
-                    await self._enqueue_active_audio(pre_silence_chunk)
-                await self._begin_silence(at_sample=res.get("end"))
+            if "end" in event and not self.current_silence:
+                end_sample = event.get("end")
+                if end_sample is None:
+                    active_slice_end = num_samples
+                else:
+                    active_slice_end = max(
+                        0,
+                        min(int(end_sample - chunk_sample_start), num_samples),
+                    )
+                start_index = active_slice_start if active_slice_start is not None else 0
+                if active_slice_end > start_index:
+                    await self._enqueue_active_audio(pcm_array[start_index:active_slice_end])
+                await self._begin_silence(at_sample=end_sample)
+                active_slice_start = None
 
         if not self.current_silence:
-            await self._enqueue_active_audio(pcm_array)
+            start_index = active_slice_start if active_slice_start is not None else 0
+            if start_index < num_samples:
+                await self._enqueue_active_audio(pcm_array[start_index:])
 
         self.total_pcm_samples = chunk_sample_end
 

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -193,17 +193,6 @@ class AudioProcessor:
         if self.args.diarization and self.diarization_queue:
             await self.diarization_queue.put(pcm_chunk.copy())
 
-    def _slice_before_silence(self, pcm_array: np.ndarray, chunk_sample_start: int, silence_sample: Optional[int]) -> Optional[np.ndarray]:
-        if silence_sample is None:
-            return None
-        relative_index = int(silence_sample - chunk_sample_start)
-        if relative_index <= 0:
-            return None
-        split_index = min(relative_index, len(pcm_array))
-        if split_index <= 0:
-            return None
-        return pcm_array[:split_index]
-
     def convert_pcm_to_float(self, pcm_buffer: Union[bytes, bytearray]) -> np.ndarray:
         """Convert PCM buffer in s16le format to normalized NumPy array."""
         return np.frombuffer(pcm_buffer, dtype=np.int16).astype(np.float32) / 32768.0
@@ -791,7 +780,7 @@ class AudioProcessor:
 
         vad_events = []
         if self.args.vac:
-            vad_events = self.vac(pcm_array)
+            vad_events = self.vac(pcm_array) or []
 
         active_slice_start = 0 if not self.current_silence else None
         for event in vad_events:

--- a/whisperlivekit/audio_processor.py
+++ b/whisperlivekit/audio_processor.py
@@ -782,38 +782,29 @@ class AudioProcessor:
         if self.args.vac:
             vad_events = self.vac(pcm_array) or []
 
-        active_slice_start = 0 if not self.current_silence else None
+        # Iterate over events in chronological order and segment the PCM chunk:
+        #   [last_offset, end_offset]   -> active audio (tail of speech)
+        #   [end_offset, start_offset]  -> silence (skip)
+        #   [start_offset, chunk_end]   -> active audio (start of new speech)
+        # This properly handles cases where both end and start events fall into the same chunk.
+        last_offset = 0
         for event in vad_events:
             if "start" in event and self.current_silence:
-                start_sample = event.get("start")
+                start_sample = int(event["start"])
+                start_offset = max(0, min(num_samples, start_sample - chunk_sample_start))
                 await self._end_silence(at_sample=start_sample)
-                if start_sample is None:
-                    active_slice_start = 0
-                else:
-                    active_slice_start = max(
-                        0,
-                        min(int(start_sample - chunk_sample_start), num_samples),
-                    )
+                last_offset = start_offset
 
             if "end" in event and not self.current_silence:
-                end_sample = event.get("end")
-                if end_sample is None:
-                    active_slice_end = num_samples
-                else:
-                    active_slice_end = max(
-                        0,
-                        min(int(end_sample - chunk_sample_start), num_samples),
-                    )
-                start_index = active_slice_start if active_slice_start is not None else 0
-                if active_slice_end > start_index:
-                    await self._enqueue_active_audio(pcm_array[start_index:active_slice_end])
+                end_sample = int(event["end"])
+                end_offset = max(0, min(num_samples, end_sample - chunk_sample_start))
+                if end_offset > last_offset:
+                    await self._enqueue_active_audio(pcm_array[last_offset:end_offset])
                 await self._begin_silence(at_sample=end_sample)
-                active_slice_start = None
+                last_offset = end_offset
 
-        if not self.current_silence:
-            start_index = active_slice_start if active_slice_start is not None else 0
-            if start_index < num_samples:
-                await self._enqueue_active_audio(pcm_array[start_index:])
+        if not self.current_silence and last_offset < num_samples:
+            await self._enqueue_active_audio(pcm_array[last_offset:])
 
         self.total_pcm_samples = chunk_sample_end
 

--- a/whisperlivekit/silero_vad_iterator.py
+++ b/whisperlivekit/silero_vad_iterator.py
@@ -296,20 +296,13 @@ class FixedVADIterator(VADIterator):
 
     def __call__(self, x, return_seconds=False):
         self.buffer = np.append(self.buffer, x)
-        ret = None
+        events = []
         while len(self.buffer) >= 512:
             r = super().__call__(self.buffer[:512], return_seconds=return_seconds)
             self.buffer = self.buffer[512:]
-            if ret is None:
-                ret = r
-            elif r is not None:
-                if "end" in r:
-                    ret["end"] = r["end"]
-                if "start" in r:
-                    ret["start"] = r["start"]
-                    if "end" in ret:
-                        del ret["end"]
-        return ret if ret != {} else None
+            if r is not None:
+                events.append(r)
+        return events
 
 
 if __name__ == "__main__":

--- a/whisperlivekit/silero_vad_iterator.py
+++ b/whisperlivekit/silero_vad_iterator.py
@@ -288,13 +288,25 @@ class VADIterator:
 class FixedVADIterator(VADIterator):
     """
     Fixed VAD Iterator that handles variable-length audio chunks, not only exactly 512 frames at once.
+
+    Return contract:
+        ``__call__`` returns a ``list[dict]`` containing all single-frame VAD events
+        produced while consuming the input, in chronological order. Each event is
+        shaped like ``{"start": int}`` or ``{"end": int}``; an empty list means
+        no event was produced for this input.
+
+    Older versions merged all events from a single call into one dict. When an
+    ``end`` event was followed by a ``start`` event in the same call, the later
+    ``start`` could delete the earlier ``end`` and hide the silence boundary from
+    downstream processing. Callers now consume the ordered event list and split
+    audio around each boundary themselves.
     """
 
     def reset_states(self):
         super().reset_states()
         self.buffer = np.array([], dtype=np.float32)
 
-    def __call__(self, x, return_seconds=False):
+    def __call__(self, x, return_seconds=False) -> list[dict]:
         self.buffer = np.append(self.buffer, x)
         events = []
         while len(self.buffer) >= 512:
@@ -310,10 +322,10 @@ if __name__ == "__main__":
     vad = FixedVADIterator(OnnxWrapper(session=load_onnx_session()))
 
     audio_buffer = np.array([0] * 512, dtype=np.float32)
-    result = vad(audio_buffer)
-    print(f"   512 samples: {result}")
+    events = vad(audio_buffer)
+    print(f"   512 samples: events={events}")
 
     # test with 511 samples
     audio_buffer = np.array([0] * 511, dtype=np.float32)
-    result = vad(audio_buffer)
-    print(f"   511 samples: {result}")
+    events = vad(audio_buffer)
+    print(f"   511 samples: events={events}")


### PR DESCRIPTION
# Summary
This PR fixes two critical bugs in the VAD and audio processing pipeline:
1. Swallowed VAD Events (https://github.com/QuentinFuxa/WhisperLiveKit/issues/363): 
FixedVADIterator would swallow "end" events if a "start" event occurred within the same audio chunk, causing separate utterances to be incorrectly concatenated.
2. Cumulative Timestamp Drift(https://github.com/QuentinFuxa/WhisperLiveKit/issues/365): 
VAD events reporting absolute timestamps from previous chunks caused double-counting of audio duration (leading to severe timestamp drift).

# Changes Made
**1. Refactor FixedVADIterator return contract**
- It now returns a chronological list of events (list[dict]) instead of a single merged dict.
- Each event contains either {"start": int} or {"end": int}.

**2. Replaced the single-event processing logic with a chronological loop over the vad_events list in `AudioProcessor.handle_pcm_data`**
- Implemented a clean, cursor-based (last_offset) array slicing mechanism

**3. Fix Timestamp Drift(Chunk Boundary Clamping)**
- We now strictly clamp both start and end samples to the current chunk boundaries ([chunk_sample_start, chunk_sample_end]). 
- This guarantees that the sum of active audio and silence durations strictly equals the physical stream duration, completely eliminating the drift.

**4. Cleanup**
- Removed the _slice_before_silence helper method, as the new last_offset logic cleanly handles all array slicing inline and renders it obsolete.
